### PR TITLE
ci: skip security scans gracefully when secrets are unavailable

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     # Requires SNYK_TOKEN to be added as a repository secret:
     # Settings → Secrets and variables → Actions → New repository secret
+    # When the secret is absent (e.g. forks or Dependabot PRs, which do not
+    # receive repository secrets) the scan is skipped instead of failing with
+    # a 401 Unauthorized.
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - uses: actions/checkout@v7
 
@@ -21,8 +26,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Run Snyk to check for vulnerabilities
+        if: env.SNYK_TOKEN != ''
         uses: snyk/actions/golang@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
         with:
           args: --severity-threshold=high
+
+      - name: Snyk Unavailable
+        if: env.SNYK_TOKEN == ''
+        run: echo "Skipping Snyk scan because SNYK_TOKEN is not available in this workflow context."

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   sonar:
+    # Dependabot PRs (and forks) cannot access repository secrets, so the
+    # SonarCloud scan cannot run there. Skip the job for Dependabot instead of
+    # reporting a misleading green "passing" check. Pushes to main and normal
+    # PRs still run the real scan.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

The **Snyk** and **SonarCloud** GitHub Actions workflows have been failing on every run. The root causes are authentication/configuration, not code:

- **Snyk** hard-failed with `401 Unauthorized` because no `SNYK_TOKEN` secret is configured. It has never passed.
- **SonarCloud** failed on every push to `main` with `Not authorized or project not found`. The "passing" runs were Dependabot PRs that silently skip the scan (Dependabot PRs don't get repository secrets), producing misleading green checks.

## Changes

- **`snyk.yml`**: move `SNYK_TOKEN` to a job-level env and guard the scan with `if: env.SNYK_TOKEN != ''`, plus a fallback `Snyk Unavailable` step. A missing token now skips the scan instead of hard-failing with a 401.
- **`sonar.yml`**: add `if: github.actor != 'dependabot[bot]'` at the job level so Dependabot PRs show as *skipped* rather than a misleading green check. Pushes to `main` and normal contributor PRs still run the real scan.

## ⚠️ Required before merge — secrets to configure

These edits stop the *misleading* failures, but the scans will only actually run once the following **repository secrets** are set (Settings → Secrets and variables → Actions):

| Secret | Current status | Action needed |
|--------|----------------|---------------|
| `SNYK_TOKEN` | **Missing** | Add a Snyk auth token (snyk.io → Account settings → Auth Token). Until added, the Snyk scan is skipped (job stays green via the `Snyk Unavailable` step). |
| `SONAR_TOKEN` | **Present but unauthorized** | Regenerate a SonarCloud token with **Execute Analysis** permission for project `dynatrace-oss_dtmgd` in org `dynatrace-oss`, then update the secret. Until fixed, the SonarCloud scan on `main` keeps failing. |

No GitHub Actions **variables** (vars) are required — only the two secrets above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)