### PR TITLE
fix: clear lint debt, fix govulncheck finding, unblock credential-failing scans

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     # Requires SNYK_TOKEN to be added as a repository secret:
     # Settings → Secrets and variables → Actions → New repository secret
+    #
+    # continue-on-error: the configured token currently lacks permission on the
+    # Snyk org below and every run fails with "401 Unauthorized / user does not
+    # have required permission on org". The scan result is reported but does not
+    # block merges. Remove this once the token has org access, so that genuine
+    # findings gate again.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   sonar:
     runs-on: ubuntu-latest
+    # continue-on-error: SONAR_TOKEN is present but not authorized for project
+    # dynatrace-oss_dtmgd, so every run fails with "Not authorized or project
+    # not found". The scan result is reported but does not block merges. Remove
+    # this once the token has Execute Analysis permission, so that quality-gate
+    # failures gate again.
+    continue-on-error: true
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -23,7 +23,7 @@ Examples:
 
   # PowerShell
   dtmgd completion powershell | Out-String | Invoke-Expression`,
-	Args:      cobra.ExactValidArgs(1),
+	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch args[0] {

--- a/cmd/ctx.go
+++ b/cmd/ctx.go
@@ -147,39 +147,6 @@ func useContext(name string) error {
 	return nil
 }
 
-func describeContext(name string) error {
-	cfg, err := LoadConfig()
-	if err != nil {
-		return err
-	}
-
-	var found *config.NamedContext
-	for i := range cfg.Contexts {
-		if cfg.Contexts[i].Name == name {
-			found = &cfg.Contexts[i]
-			break
-		}
-	}
-	if found == nil {
-		return fmt.Errorf("context %q not found", name)
-	}
-
-	const w = 12
-	suffix := ""
-	if found.Name == cfg.CurrentContext {
-		suffix = " (current)"
-	}
-	output.DescribeKV("Name:", w, "%s%s", found.Name, suffix)
-	output.DescribeKV("Host:", w, "%s", found.Context.Host)
-	output.DescribeKV("Env-ID:", w, "%s", found.Context.EnvID)
-	output.DescribeKV("Token-Ref:", w, "%s", found.Context.TokenRef)
-	if found.Context.Description != "" {
-		output.DescribeKV("Description:", w, "%s", found.Context.Description)
-	}
-	output.DescribeKV("API URL:", w, "%s/v2/", found.Context.APIBaseURL())
-	return nil
-}
-
 func setContext(name, host, envID, tokenRef, description string) error {
 	cfg, err := loadConfigRaw()
 	if err != nil {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -57,7 +57,8 @@ func runWatch(fn func() error) error {
 }
 
 func clearScreen() {
-	fmt.Fprint(os.Stdout, "\033[H\033[2J")
+	// Best effort: a failed terminal escape sequence is cosmetic only.
+	_, _ = fmt.Fprint(os.Stdout, "\033[H\033[2J")
 }
 
 func printWatchHeader() {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dynatrace-oss/dtmgd
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/adrg/xdg v0.5.3

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,7 +120,11 @@ func Load() (*Config, error) {
 
 // LoadFrom loads config from the given path.
 func LoadFrom(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
+	// #nosec G304 -- reading a caller-supplied config path is this function's
+	// purpose. The path comes from --config, a discovered .dtmgd.yaml, or the
+	// XDG default, and dtmgd runs with the invoking user's own privileges, so
+	// there is no privilege boundary to cross here.
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("config file not found at %s. Run 'dtmgd config set-context' to create one", path)

--- a/pkg/output/agent.go
+++ b/pkg/output/agent.go
@@ -81,5 +81,7 @@ func PrintAgentError(err error) {
 		Error: &AgentError{Code: "error", Message: err.Error()},
 	}
 	data, _ := json.MarshalIndent(resp, "", "  ")
-	fmt.Fprintln(os.Stdout, string(data))
+	// Best effort: this is the last-resort error reporter, so there is nothing
+	// useful to do if writing to stdout fails.
+	_, _ = fmt.Fprintln(os.Stdout, string(data))
 }

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -36,7 +36,7 @@ func (p *TablePrinter) columnRequested(header string) bool {
 // PrintList accepts either a slice or a single struct, printing rows to a table.
 func (p *TablePrinter) PrintList(v interface{}) error {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 
@@ -50,19 +50,21 @@ func (p *TablePrinter) PrintList(v interface{}) error {
 	}
 
 	if len(rows) == 0 {
-		fmt.Fprintln(p.w, "No items found.")
-		return nil
+		_, err := fmt.Fprintln(p.w, "No items found.")
+		return err
 	}
 
 	// Determine element type
 	elemType := rows[0].Type()
-	if elemType.Kind() == reflect.Ptr {
+	if elemType.Kind() == reflect.Pointer {
 		elemType = elemType.Elem()
 	}
 	if elemType.Kind() != reflect.Struct {
-		// Fallback: just print each value
+		// Fallback: print each value on its own line
 		for _, r := range rows {
-			fmt.Fprintln(p.w, r.Interface())
+			if _, err := fmt.Fprintln(p.w, r.Interface()); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -90,8 +92,8 @@ func (p *TablePrinter) PrintList(v interface{}) error {
 	}
 
 	if len(headers) == 0 {
-		fmt.Fprintln(p.w, v)
-		return nil
+		_, err := fmt.Fprintln(p.w, v)
+		return err
 	}
 
 	// WithHeaderAutoFormat must precede WithHeader: WithHeader applies the
@@ -118,7 +120,7 @@ func (p *TablePrinter) PrintList(v interface{}) error {
 
 	for _, row := range rows {
 		rv := row
-		if rv.Kind() == reflect.Ptr {
+		if rv.Kind() == reflect.Pointer {
 			rv = rv.Elem()
 		}
 		var cells []string

--- a/pkg/skills/installer.go
+++ b/pkg/skills/installer.go
@@ -198,7 +198,7 @@ func copyEmbeddedFS(embeddedFS fs.FS, destDir string) error {
 		destPath := filepath.Join(destDir, path)
 
 		if d.IsDir() {
-			return os.MkdirAll(destPath, 0o755)
+			return os.MkdirAll(destPath, 0o750)
 		}
 
 		data, err := fs.ReadFile(embeddedFS, path)
@@ -207,11 +207,11 @@ func copyEmbeddedFS(embeddedFS fs.FS, destDir string) error {
 		}
 
 		dir := filepath.Dir(destPath)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
 			return fmt.Errorf("creating directory %s: %w", dir, err)
 		}
 
-		return os.WriteFile(destPath, data, 0o644)
+		return os.WriteFile(destPath, data, 0o600)
 	})
 }
 


### PR DESCRIPTION
Four CI jobs have been failing on every run. They have three distinct causes, so they get three distinct treatments. No cause is papered over.

## 1. `sast` / golangci-lint — pre-existing lint debt (fixed)

Failed **12 of its last 12 runs**, all on debt unrelated to any recent change. `golangci-lint run ./...` now reports **0 issues**.

**errcheck** — check or explicitly discard write results:
- `pkg/output/table.go`: `PrintList` already returns `error`, so the three `Fprintln` results are now propagated instead of dropped. This is a real (if minor) behavior improvement: write failures were previously silent.
- `pkg/output/agent.go`, `cmd/watch.go`: explicit `_, _ =` plus a comment. Both are `void` best-effort writes — the last-resort error reporter and a cosmetic terminal escape — so there is genuinely nothing to propagate.

**gosec**:
- `pkg/skills/installer.go` (G301/G306): tighten skill-install permissions to `0750` dirs / `0600` files. These are per-user agent config directories, written and read back by an agent running as the same user. Verified `dtmgd skills install --for claude` still works and produces `750`/`600`.
- `pkg/config/config.go` (G304): annotated `#nosec` with justification. Reading a caller-supplied config path is the function's entire purpose (`--config`, a discovered `.dtmgd.yaml`, or the XDG default), and dtmgd runs with the invoking user's privileges, so there is no privilege boundary to cross. Also added `filepath.Clean`.

**staticcheck SA1019**: `cobra.ExactValidArgs` is deprecated → `cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)`. Verified the validator still accepts `bash` and rejects both an invalid shell and an extra argument.

**unused**: removed `cmd/ctx.go:describeContext`. It had no callers and was never wired to a command — `dtmgd ctx` exposes `current` and `delete` only. Flagging explicitly in case it was intended for a future `ctx describe`; it is recoverable from history.

**govet**: `reflect.Ptr` → `reflect.Pointer` (3 sites).

## 2. `security` / govulncheck — a real vulnerability (fixed, not suppressed)

This one is **not** a credentials problem:

```
Vulnerability #1: GO-2026-5856
    Found in: crypto/tls@go1.25.11
    Fixed in: crypto/tls@go1.25.12
    #1: pkg/client/client.go:216:22: client.Client.GetCluster calls
        resty.Request.Get, which eventually calls tls.Conn.HandshakeContext
```

`go.mod` pinned `toolchain go1.25.11`, the affected version. Bumped to `go1.25.12` — both the fix version and the latest patch on the 1.25 line. Verified:

```
$ GOTOOLCHAIN=go1.25.12 govulncheck ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

**`security.yml` deliberately keeps gating.** A reachable stdlib vulnerability should block, so it was fixed rather than marked `continue-on-error`.

## 3. `snyk` and `sonar` — credential failures (unblocked, not fixed)

Both fail on permissions that no contributor can resolve:

```
Snyk:  ERROR Authentication error (SNYK-0005)
       user does not have required permission on org
       Status: 401 Unauthorized

Sonar: ERROR Not authorized or project not found. Please check the
       'SONAR_TOKEN' environment variable, the 'sonar.projectKey' and
       'sonar.organization' properties...
```

Both secrets **exist** — this is not the "secret is absent" case that the existing `if: env.SONAR_TOKEN != ''` guard handles. Marked `continue-on-error: true` so their output stays visible without blocking merges, each with a comment saying to remove it once the token works.

**These jobs are not fixed, only unblocked.** They need admin action:

| Secret | Needs |
|---|---|
| `SNYK_TOKEN` | permission on Snyk org `cf209dc7-eeb0-489a-822b-bcf09c4d1b8a` |
| `SONAR_TOKEN` | **Execute Analysis** on project `dynatrace-oss_dtmgd` |

## Verification

- `golangci-lint run ./...` → 0 issues (v2.6.2, matching the repo's `version: "2"` config)
- `GOTOOLCHAIN=go1.25.12 govulncheck ./...` → no vulnerabilities
- `go build ./...`, `go vet ./...`, `gofmt` clean
- `cmd`, `pkg/client`, `pkg/config`, `pkg/output` tests pass
- Workflow YAML parse-validated
- Smoke-tested against two live Dynatrace Managed environments: `get environments` multi-env fan-out, `completion` arg validation, and `skills install`

`pkg/skills` has two failing tests locally (`TestInstallAndStatusAndUninstall`, `TestStatusAll`) — **pre-existing and environmental**, not touched by this PR. They assume a pristine `HOME` and fail on a machine that already has the dtmgd skill installed globally; they pass on CI runners.

## Related

Supersedes #19, which was closed: it targeted the "secret absent" case, which is no longer the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)