### PR TITLE
fix: stop writing expanded env vars back into the config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +19,10 @@ type Config struct {
 	Tokens         []NamedToken      `yaml:"tokens"`
 	Preferences    Preferences       `yaml:"preferences"`
 	Aliases        map[string]string `yaml:"aliases,omitempty"`
+
+	// Set when the file this config was read from contained ${VAR} references,
+	// whose expansion must not be written back.
+	expandedFrom string
 }
 
 // NamedContext holds a named context entry.
@@ -138,6 +143,9 @@ func LoadFrom(path string) (*Config, error) {
 	if err := yaml.Unmarshal(expanded, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
+	if !bytes.Equal(data, expanded) {
+		cfg.expandedFrom = path
+	}
 	// Apply defaults for fields that may be absent in minimal configs.
 	if cfg.APIVersion == "" {
 		cfg.APIVersion = "dtmgd.io/v1"
@@ -155,6 +163,9 @@ func (c *Config) Save() error {
 
 // SaveTo saves the config to a specific path.
 func (c *Config) SaveTo(path string) error {
+	if c.expandedFrom != "" && sameFile(c.expandedFrom, path) {
+		return fmt.Errorf("refusing to overwrite %s: it references environment variables, and saving would replace them with their current values. Edit the file directly instead", path)
+	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
@@ -281,4 +292,14 @@ func NewConfig() *Config {
 		Tokens:      []NamedToken{},
 		Preferences: Preferences{Output: "table"},
 	}
+}
+
+// sameFile reports whether two paths point at the same config file.
+func sameFile(a, b string) bool {
+	if a == b {
+		return true
+	}
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	return errA == nil && errB == nil && absA == absB
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -434,4 +435,52 @@ func TestFindLocalConfigNotFound(t *testing.T) {
 	// Just call FindLocalConfig — it may or may not find something (depending on
 	// whether there's a .dtmgd.yaml above the tmp dir). Just ensure no panic.
 	_ = FindLocalConfig()
+}
+
+func TestSaveToKeepsEnvPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, LocalConfigName)
+	original := `apiVersion: dtmgd.io/v1
+kind: Config
+current-context: prod
+contexts:
+  - name: prod
+    context:
+      host: ${DT_MANAGED_HOST}
+      env-id: ${DT_ENV_ID}
+      token-ref: prod
+tokens:
+  - name: prod
+    token: ${DT_API_TOKEN}
+`
+	if err := os.WriteFile(path, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DT_MANAGED_HOST", "https://managed.example.com")
+	t.Setenv("DT_ENV_ID", "abc12345")
+	t.Setenv("DT_API_TOKEN", "dt0c01.SECRET.VALUE")
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Tokens[0].Token; got != "dt0c01.SECRET.VALUE" {
+		t.Fatalf("token = %q, want the expanded value", got)
+	}
+
+	if err := cfg.SaveTo(path); err == nil {
+		t.Error("SaveTo overwrote a config that references environment variables")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != original {
+		t.Errorf("config file was rewritten:\n%s", after)
+	}
+	if strings.Contains(string(after), "dt0c01.SECRET.VALUE") {
+		t.Error("the expanded token was written into the config file")
+	}
 }


### PR DESCRIPTION
`config.LoadFrom` expands environment variables in the file it reads:

```go
expanded := []byte(os.ExpandEnv(string(data)))
```

and `SaveTo` later marshals the in-memory config straight back over the same path. nothing keeps the two apart

that matters because `dtmgd config init` deliberately seeds the file with placeholders, and the README documents them:

```yaml
host: ${DT_MANAGED_HOST}
env-id: ${DT_ENV_ID}
token: ${DT_API_TOKEN}
```

so any command that touches the config, `ctx`, `config use-context`, `set-context`, `set-credentials`, `delete-context`, `migrate-tokens`, goes through `saveConfig` and permanently replaces those placeholders with whatever the variables held at that moment. a live api token ends up written into `.dtmgd.yaml`, which normally sits in a repository, and the next `git add .` commits it

the mirror case is just as bad: with the variables unset the same path writes empty strings and quietly empties the config, while printing that the context was switched

## changes

remember the path a config was expanded from, and refuse to overwrite that file, with an error saying to edit it directly

I went with refusing rather than restoring the placeholders on save. round-tripping `${VAR}` through the yaml node tree is a much larger change, and refusing already removes both the leak and the silent wipe. happy to do the round-trip version instead if you would rather keep those commands working on a placeholder config

## testing

a test writes a config full of placeholders, sets the variables, loads it, and asserts that saving is refused and the file on disk is byte for byte unchanged with no token in it

without the change all three assertions fail, including the one checking the token is not in the file. `go test ./...` is green, `go vet ./...` and `golangci-lint run ./...` are clean