### PR TITLE
test(config): cover SetToken's no-keyring branch

### DIFF
--- a/pkg/config/keyring_test.go
+++ b/pkg/config/keyring_test.go
@@ -21,6 +21,81 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// withoutKeyring makes IsKeyringAvailable() report false for the duration of
+// one test, then restores the working mock installed by TestMain.
+//
+// Swapping the package-global provider is safe here because no test in this
+// package calls t.Parallel, so they run sequentially.
+func withoutKeyring(t *testing.T) {
+	t.Helper()
+	keyring.MockInitWithError(keyring.ErrUnsupportedPlatform)
+	t.Cleanup(keyring.MockInit)
+}
+
+// TestSetTokenPlaintextBranch covers SetToken's no-keyring path: the branch
+// taken on a headless Linux box with no secret-service backend, which is a
+// real production path rather than a rare fallback.
+//
+// It needs withoutKeyring because TestMain installs a working mock for the
+// whole binary, so IsKeyringAvailable() otherwise reports true for every test
+// and this branch never executes.
+func TestSetTokenPlaintextBranch(t *testing.T) {
+	withoutKeyring(t)
+
+	if IsKeyringAvailable() {
+		t.Fatal("IsKeyringAvailable() = true, want false")
+	}
+
+	cfg := &Config{Tokens: []NamedToken{{Name: "existing", Token: "old-value"}}}
+
+	// Updating an existing entry writes the token into the config, rather than
+	// blanking it as the keyring branch does.
+	if err := cfg.SetToken("existing", "updated-value"); err != nil {
+		t.Fatalf("SetToken() error = %v", err)
+	}
+	if got := cfg.Tokens[0].Token; got != "updated-value" {
+		t.Errorf("existing token = %q, want %q", got, "updated-value")
+	}
+
+	// Creating a new entry appends it, again with the value inline.
+	if err := cfg.SetToken("fresh", "fresh-value"); err != nil {
+		t.Fatalf("SetToken() error = %v", err)
+	}
+	if len(cfg.Tokens) != 2 {
+		t.Fatalf("len(Tokens) = %d, want 2", len(cfg.Tokens))
+	}
+	if cfg.Tokens[1].Name != "fresh" || cfg.Tokens[1].Token != "fresh-value" {
+		t.Errorf("appended token = %+v, want {fresh fresh-value}", cfg.Tokens[1])
+	}
+
+	// The value must be readable back through the plaintext branch of GetToken.
+	got, err := cfg.GetToken("fresh")
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got != "fresh-value" {
+		t.Errorf("GetToken() = %q, want %q", got, "fresh-value")
+	}
+}
+
+// TestSetTokenPlaintextBranchExpandsOnRead confirms that a ${VAR} reference
+// stored in the config is still resolved at read time when no keyring is
+// available — the placeholder must not be handed out verbatim as a token.
+func TestSetTokenPlaintextBranchExpandsOnRead(t *testing.T) {
+	withoutKeyring(t)
+	t.Setenv("DT_PLAINTEXT_TEST_TOKEN", "dt0c01.RESOLVED")
+
+	cfg := &Config{Tokens: []NamedToken{{Name: "prod", Token: "${DT_PLAINTEXT_TEST_TOKEN}"}}}
+
+	got, err := cfg.GetToken("prod")
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got != "dt0c01.RESOLVED" {
+		t.Errorf("GetToken() = %q, want the expanded value", got)
+	}
+}
+
 // TestMigrateTokensSkipsPlaceholders verifies the accounting without touching
 // the OS keyring: with every token either empty or a placeholder, SetToken is
 // never reached, so the test is safe on headless CI.


### PR DESCRIPTION
Follow-up to #29.

## Why

#29 added a `TestMain` calling `keyring.MockInit()` to the `pkg/config` and `cmd` test binaries. That was necessary — before it, `go test ./cmd/...` reached `keyring.Set("dtmgd", "prod-token", …)` and silently overwrote a developer's live API token, using the exact credential name from the README quick start. Headless CI took the other branch, so CI never surfaced it.

The mock has a side effect: `IsKeyringAvailable()` now reports **true** for every test in those binaries, so `SetToken`'s plaintext branch stopped being exercised. That branch is a real production path — any headless Linux box without a secret-service backend takes it — and it behaves differently in a way that matters: it writes the token *into the config file* rather than blanking it and delegating to the keyring.

## Why line coverage didn't catch it

`SetToken` reports 90.9% both before and after this change. Both branches traverse the same lines; the keyring branch just sets `token = ""` first and falls through to the same loop. The uncovered 9.1% is the keyring error return, not the plaintext path.

So the gap was semantic, not line-level. I confirmed it was real with a mutation — forcing the keyring branch always-taken (`if IsKeyringAvailable()` → `if true`) — and running the package suite:

```
--- FAIL: TestSetTokenPlaintextBranch
FAIL    github.com/dynatrace-oss/dtmgd/pkg/config
```

The new test is the only one in the package that catches it.

## What's here

- `withoutKeyring(t)` — swaps in `keyring.MockInitWithError(keyring.ErrUnsupportedPlatform)` for one test and restores the working mock via `t.Cleanup`. Safe because no test in the package calls `t.Parallel`, so they run sequentially. `ErrUnsupportedPlatform` lives in `keyring_fallback.go`, which carries no build tags, so it resolves on every platform.
- `TestSetTokenPlaintextBranch` — asserts the create and update paths both store the value inline, and that `GetToken` reads it back through the plaintext branch.
- `TestSetTokenPlaintextBranchExpandsOnRead` — a `${VAR}` reference stored in the config must still resolve at read time when no keyring is available, rather than being handed out verbatim as a token.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)