### PR TITLE
fix(deps): raise golang.org/x/crypto floor past the ssh CVEs (PRISM-14120..14125)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,6 @@ require (
 	github.com/olekukonko/errors v1.2.0 // indirect
 	github.com/olekukonko/ll v0.1.6 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -49,11 +49,11 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
Closes six Snyk-sourced Jira vulnerability tickets — **PRISM-14120, -14121, -14122, -14123, -14124, -14125** — which all report the same package at the same version and all ask for the same fixed version.

## The finding

| CVE | Subpackage | Class | Snyk CVSS |
|---|---|---|---|
| CVE-2026-46598 | `ssh/agent` | Incorrect Type Conversion or Cast | 8.7 |
| CVE-2026-46597 | `ssh` | Incorrect Type Conversion or Cast | 8.7 |
| CVE-2026-42508 | `ssh/knownhosts` | Improper Check for Certificate Revocation | 8.7 |
| CVE-2026-39835 | `ssh` | Uncaught Exception | 8.7 |
| CVE-2026-39831 | `ssh` | Improper Authentication | 8.6 |
| CVE-2026-39827 | `ssh` | Missing Release of Resource | 7.1 |

All six: `golang.org/x/crypto@v0.51.0`, fixed in `v0.52.0`.

## Reachability: none

dtmgd imports no `golang.org/x/crypto` package, and every one of the six lives in the `ssh` subtree — an SSH client/server this REST CLI has no use for.

`x/crypto` is a **phantom module-graph entry**. It shows up in `go list -m all` because `golang.org/x/net`'s go.mod requires it, but it has **no `go.sum` entry**, so nothing from it is ever downloaded or linked. govulncheck confirms this independently: it never mentions `x/crypto` at all, because the module contributes no package to the build.

These are worth clearing to keep the gating Snyk scan clean, not because the binary was exposed.

## The fix

Pinning the unused module directly would not survive — `go mod tidy` drops a requirement no package imports. So this bumps the dependency that actually puts it in the graph:

```
golang.org/x/net  v0.55.0 -> v0.57.0   (its go.mod requires x/crypto v0.54.0)
golang.org/x/sys  v0.45.0 -> v0.47.0   (pulled along)
```

`x/crypto` now resolves to **v0.54.0**, past the v0.52.0 floor and durable across future `go mod tidy` runs. Two lines in go.mod; no source changes.

## Bonus: a real finding Snyk missed

`x/net` is a genuine dependency — resty's cookie jar imports `golang.org/x/net/publicsuffix` — so this bump also fixes something govulncheck caught and Snyk did not report:

> **GO-2026-5942** — parsing an invalid SVCB or HTTPS RR can panic in `golang.org/x/net/dns/dnsmessage`. Present in v0.55.0, fixed in v0.56.0.

Uncalled by our code, but a module we actually build against.

## Verification

`govulncheck` before vs. after, same toolchain:

| | vulnerabilities in modules you require |
|---|---|
| `main` | **1** (GO-2026-5942, `x/net@v0.55.0`) |
| this branch | **0** |

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean
- `go test ./pkg/config/... ./pkg/client/... ./cmd/... ./pkg/output/...` — all `ok`

## Out of scope

govulncheck also reports three *reachable* standard-library findings (`crypto/tls` GO-2026-5856, `net/textproto` GO-2026-5039, `crypto/x509` GO-2026-5037). Their output is **byte-identical before and after this commit** — they track the Go toolchain version, not this module's dependencies, and are fixed by a toolchain bump rather than a dependency change. Flagged separately; deliberately not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)