### PR TITLE
fix: harden error output and unify the HTTP client (PRISM-13823 notes 2, 7, 8, 10, 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ dtmgd query log-counts --entity 'type(SERVICE),tag("[Environment]BookStore")' --
 | `-A, --agent` | Force AI agent envelope output (`{ok, result, context}`) |
 | `--no-agent` | Disable auto-detected agent mode |
 | `--max-pages <n>` | Maximum pages to fetch (0 = all, default). Pagination is automatic. |
+| `--concurrency <n>` | Maximum environments queried at once with `--env` (default: `10`) |
 | `--columns <cols>` | Comma-separated columns to show in table output |
 | `-w, --watch` | Re-run the command periodically |
 | `--watch-interval <d>` | Interval between watch refreshes (default: `5s`) |
@@ -220,6 +221,17 @@ dtmgd get problems --env "eu-prod;us-prod;ap-prod;dev" -o json
 
 The `--env` flag works with all `get`, `describe`, and `query` commands.
 
+Environments are queried in parallel, up to 10 at a time. Since a Managed
+cluster commonly hosts 20-50 environment IDs, firing them all at once draws
+`429 Too Many Requests`, and every request then retries on the same schedule —
+so each retry wave is as large as the original burst, and no output appears
+until the slowest one finishes. Raise the cap with `--concurrency` if your
+cluster is dedicated or you have only a few environments:
+
+```bash
+dtmgd get problems --env ALL_ENVIRONMENTS --concurrency 25
+```
+
 ## AI Agent Mode
 
 When running inside an AI agent (Claude Code, Cursor, GitHub Copilot, Kiro, etc.),
@@ -238,9 +250,13 @@ Errors are also wrapped:
 ```json
 {
   "ok": false,
-  "error": { "code": "error", "message": "API error 401: Unauthorized" }
+  "error": { "code": "error", "message": "API error 401" }
 }
 ```
+
+API error messages carry the status code and, when the cluster returns a
+recognised error envelope, its human-readable message — but not the rest of the
+response body. Run with `-vv` to see the full response.
 
 Force it on with `-A` / `--agent`, or disable auto-detection with `--no-agent`.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ var (
 	noAgentFlag  bool
 	maxPages     int
 	columns      string
+	concurrency  int
 )
 
 // agentMode returns true if agent envelope output should be used.
@@ -169,6 +170,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noAgentFlag, "no-agent", false, "disable auto-detected agent mode")
 	rootCmd.PersistentFlags().IntVar(&maxPages, "max-pages", 0, "maximum number of pages to fetch (0 = all pages)")
 	rootCmd.PersistentFlags().StringVar(&columns, "columns", "", "comma-separated list of columns to show in table output")
+	rootCmd.PersistentFlags().IntVar(&concurrency, "concurrency", client.DefaultConcurrency,
+		"maximum environments queried at once with --env")
 }
 
 // LoadConfig loads the configuration, respecting --config and --context flags.
@@ -349,7 +352,7 @@ func multiExec(cfg *config.Config, apiCall func(c *client.Client) (interface{}, 
 		}
 		return apiCall(c)
 	}
-	results, err := client.MultiRequest(cfg, spec, apiCall)
+	results, err := client.MultiRequest(cfg, spec, concurrency, apiCall)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,12 +18,24 @@ import (
 
 // Client is the HTTP client for the Dynatrace Managed API.
 type Client struct {
-	http         *resty.Client
+	http *resty.Client
+	// cluster targets the cluster-level API. It is built alongside http and
+	// carries the same proxy, retry, header and debug-hook configuration:
+	// GetCluster used to call resty.New() for every request, which silently
+	// bypassed all of it — most consequentially the proxy, so `get
+	// environments` escaped corporate egress controls that every other
+	// command respected.
+	cluster      *resty.Client
 	apiBaseURL   string // {host}/e/{env-id}/api
 	clusterURL   string // {host}/api
 	dashboardURL string // {host}/e/{env-id}
 	token        string
-	logger       *logrus.Logger
+	// proxyURL is the proxy actually in effect, retained so that it can be
+	// named in verbose output and in connection errors. Without it, "proxy
+	// configured and working", "proxy configured and ignored", and "no proxy"
+	// are indistinguishable from anything dtmgd prints.
+	proxyURL string
+	logger   *logrus.Logger
 }
 
 // NewFromConfig creates a Client from the current config context.
@@ -74,27 +86,41 @@ func New(host, envID, token string) (*Client, error) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.WarnLevel)
 
-	ua := fmt.Sprintf("dtmgd/%s", version.Version)
-
-	httpClient := resty.New().
-		SetBaseURL(apiBaseURL).
-		SetHeader("Authorization", fmt.Sprintf("Api-Token %s", token)).
-		SetHeader("Content-Type", "application/json").
-		SetHeader("User-Agent", ua).
-		SetRetryCount(3).
-		SetRetryWaitTime(1 * time.Second).
-		SetRetryMaxWaitTime(10 * time.Second).
-		AddRetryCondition(isRetryable).
-		SetTimeout(60 * time.Second)
-
 	return &Client{
-		http:         httpClient,
+		http:         newRestyClient(apiBaseURL, token, 60*time.Second),
+		cluster:      newRestyClient(clusterURL, token, 30*time.Second),
 		apiBaseURL:   apiBaseURL,
 		clusterURL:   clusterURL,
 		dashboardURL: dashboardURL,
 		token:        token,
 		logger:       logger,
 	}, nil
+}
+
+// newRestyClient builds a resty client with the settings every dtmgd request
+// is expected to carry.
+//
+// It exists so the environment and cluster clients cannot drift apart: the
+// cluster client was previously constructed inline in GetCluster with none of
+// the retry, User-Agent or proxy configuration, which made `get environments`
+// behave unlike every other command.
+func newRestyClient(baseURL, token string, timeout time.Duration) *resty.Client {
+	return resty.New().
+		SetBaseURL(baseURL).
+		SetHeader("Authorization", fmt.Sprintf("Api-Token %s", token)).
+		SetHeader("Content-Type", "application/json").
+		SetHeader("User-Agent", fmt.Sprintf("dtmgd/%s", version.Version)).
+		SetRetryCount(3).
+		SetRetryWaitTime(1 * time.Second).
+		SetRetryMaxWaitTime(10 * time.Second).
+		AddRetryCondition(isRetryable).
+		SetTimeout(timeout)
+}
+
+// clients returns every resty client this Client owns, so configuration
+// applied after construction reaches all of them.
+func (c *Client) clients() []*resty.Client {
+	return []*resty.Client{c.http, c.cluster}
 }
 
 // isRetryable decides whether a failed request should be retried.
@@ -118,41 +144,76 @@ func (c *Client) SetVerbosity(level int) {
 		DisableLevelTruncation: true,
 	})
 
-	c.http.SetPreRequestHook(func(_ *resty.Client, req *http.Request) error {
-		fmt.Fprintf(os.Stderr, "==> %s %s\n", req.Method, req.URL)
-		if level >= 2 {
-			for k, v := range req.Header {
-				if strings.EqualFold(k, "authorization") {
-					fmt.Fprintf(os.Stderr, "    %s: [REDACTED]\n", k)
-				} else {
-					fmt.Fprintf(os.Stderr, "    %s: %s\n", k, strings.Join(v, ", "))
+	for _, rc := range c.clients() {
+		rc.SetPreRequestHook(func(_ *resty.Client, req *http.Request) error {
+			// Naming the proxy on the request line is what makes an active
+			// proxy distinguishable from none at all. Previously no verbosity
+			// level printed it, so a user who suspected their proxy was being
+			// bypassed had to reach for tcpdump to find out.
+			via := ""
+			if c.proxyURL != "" {
+				via = fmt.Sprintf(" (via proxy %s)", c.proxyURL)
+			}
+			fmt.Fprintf(os.Stderr, "==> %s %s%s\n", req.Method, req.URL, via)
+			if level >= 2 {
+				for k, v := range req.Header {
+					if strings.EqualFold(k, "authorization") {
+						fmt.Fprintf(os.Stderr, "    %s: [REDACTED]\n", k)
+					} else {
+						fmt.Fprintf(os.Stderr, "    %s: %s\n", k, strings.Join(v, ", "))
+					}
 				}
 			}
-		}
-		return nil
-	})
+			return nil
+		})
 
-	c.http.OnAfterResponse(func(_ *resty.Client, resp *resty.Response) error {
-		fmt.Fprintf(os.Stderr, "<== %d %s (%s)\n", resp.StatusCode(), resp.Status(), resp.Time())
-		if level >= 2 {
-			fmt.Fprintf(os.Stderr, "%s\n", resp.String())
-		}
-		return nil
-	})
+		rc.OnAfterResponse(func(_ *resty.Client, resp *resty.Response) error {
+			fmt.Fprintf(os.Stderr, "<== %d %s (%s)\n", resp.StatusCode(), resp.Status(), resp.Time())
+			if level >= 2 {
+				fmt.Fprintf(os.Stderr, "%s\n", resp.String())
+			}
+			return nil
+		})
+	}
 }
 
 // APIBaseURL returns the environment API base URL.
 func (c *Client) APIBaseURL() string { return c.apiBaseURL }
 
 // SetProxy configures HTTP/HTTPS proxy on the client.
+//
+// The proxy is applied to the cluster client too. It previously was not, so
+// `get environments` connected directly while every other command went
+// through the proxy — leaving proxy audit logs with an incomplete picture of
+// dtmgd activity, and bypassing egress controls in environments that require
+// them.
 func (c *Client) SetProxy(httpProxy, httpsProxy string) {
 	proxy := httpsProxy
 	if proxy == "" {
 		proxy = httpProxy
 	}
-	if proxy != "" {
-		c.http.SetProxy(proxy)
+	if proxy == "" {
+		return
 	}
+	c.proxyURL = proxy
+	for _, rc := range c.clients() {
+		rc.SetProxy(proxy)
+	}
+}
+
+// requestError annotates a transport failure with the proxy it went through.
+//
+// A wrong proxy address otherwise surfaces as a bare "dial tcp: lookup
+// bad-proxy.internal: no such host", which names a host the user never typed
+// into their context and does not say why dtmgd was trying to reach it.
+//
+// The underlying error is wrapped rather than replaced, so DiagnoseError still
+// matches on "no such host", "connection refused" and the rest.
+func (c *Client) requestError(what string, err error) error {
+	if c.proxyURL != "" {
+		return fmt.Errorf("%s failed (via proxy %s): %w", what, c.proxyURL, err)
+	}
+	return fmt.Errorf("%s failed: %w", what, err)
 }
 
 // ClusterURL returns the cluster-level API base URL.
@@ -170,7 +231,7 @@ func (c *Client) GetV2(path string, params map[string]string, result interface{}
 	}
 	resp, err := req.Get("/v2" + path)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.requestError("request", err)
 	}
 	if resp.IsError() {
 		return APIError(resp.StatusCode(), resp.String())
@@ -185,7 +246,7 @@ func (c *Client) GetV2WithValues(path string, params url.Values, result interfac
 	req.SetQueryParamsFromValues(params)
 	resp, err := req.Get("/v2" + path)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.requestError("request", err)
 	}
 	if resp.IsError() {
 		return APIError(resp.StatusCode(), resp.String())
@@ -201,7 +262,7 @@ func (c *Client) GetV1(path string, params map[string]string, result interface{}
 	}
 	resp, err := req.Get("/v1" + path)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.requestError("request", err)
 	}
 	if resp.IsError() {
 		return APIError(resp.StatusCode(), resp.String())
@@ -210,21 +271,17 @@ func (c *Client) GetV1(path string, params map[string]string, result interface{}
 }
 
 // GetCluster performs a GET against the cluster-level API (/api/v1.0/onpremise/...).
-// Uses a temporary resty client rooted at clusterURL.
+//
+// It uses the cluster client built in New, which shares the environment
+// client's proxy, retry policy, User-Agent and verbosity hooks.
 func (c *Client) GetCluster(path string, params map[string]string, result interface{}) error {
-	tmpClient := resty.New().
-		SetBaseURL(c.clusterURL).
-		SetHeader("Authorization", fmt.Sprintf("Api-Token %s", c.token)).
-		SetHeader("Content-Type", "application/json").
-		SetTimeout(30 * time.Second)
-
-	req := tmpClient.R().SetResult(result)
+	req := c.cluster.R().SetResult(result)
 	for k, v := range params {
 		req.SetQueryParam(k, v)
 	}
 	resp, err := req.Get(path)
 	if err != nil {
-		return fmt.Errorf("cluster request failed: %w", err)
+		return c.requestError("cluster request", err)
 	}
 	if resp.IsError() {
 		return APIError(resp.StatusCode(), resp.String())

--- a/pkg/client/cluster_test.go
+++ b/pkg/client/cluster_test.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetClusterUsesSharedClientSettings is the observable half of the
+// GetCluster finding. The cluster request used to come from a bare
+// resty.New(), so it carried none of the configuration every other request
+// had: no User-Agent (cluster access logs could not attribute the traffic to
+// dtmgd), no retry, no debug hooks, and — the reason this matters — no proxy.
+func TestGetClusterUsesSharedClientSettings(t *testing.T) {
+	var gotUA, gotAuth, gotContentType string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"version":"1.300.0"}`)); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, "env1", "mytoken")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	var result struct {
+		Version string `json:"version"`
+	}
+	if err := c.GetCluster("/v1.0/onpremise/cluster", nil, &result); err != nil {
+		t.Fatalf("GetCluster() error = %v", err)
+	}
+
+	if result.Version != "1.300.0" {
+		t.Errorf("Version = %q, want the decoded body", result.Version)
+	}
+	if !strings.HasPrefix(gotUA, "dtmgd/") {
+		t.Errorf("User-Agent = %q, want the dtmgd agent — cluster logs cannot attribute the request otherwise", gotUA)
+	}
+	if gotAuth != "Api-Token mytoken" {
+		t.Errorf("Authorization = %q, want the API token header", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+}
+
+// TestSetProxyReachesClusterClient pins the proxy fix directly. Setting a
+// proxy that cannot be resolved must break the cluster request too — if it
+// still succeeds, GetCluster is bypassing the proxy exactly as the finding
+// described, and in a corporate deployment it would be bypassing egress
+// controls with it.
+//
+// This test takes several seconds: the cluster client now shares the retry
+// policy, so the unreachable proxy is retried three times with backoff. That
+// delay is the fix working, not a hang.
+func TestSetProxyReachesClusterClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{"version":"1.300.0"}`)); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, "env1", "mytoken")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	c.SetProxy("", "http://proxy.invalid.dtmgd-test:9999")
+
+	var result struct {
+		Version string `json:"version"`
+	}
+	err = c.GetCluster("/v1.0/onpremise/cluster", nil, &result)
+
+	if err == nil {
+		t.Fatal("GetCluster() succeeded through an unreachable proxy — the proxy is being bypassed")
+	}
+	// The error must name the proxy: a bare "no such host" for a hostname the
+	// user never typed into their context is what made this hard to diagnose.
+	if !strings.Contains(err.Error(), "proxy.invalid.dtmgd-test:9999") {
+		t.Errorf("error does not name the proxy that was attempted: %v", err)
+	}
+}
+
+// TestRequestErrorWithoutProxyIsUnchanged keeps the annotation from becoming
+// noise when no proxy is configured.
+func TestRequestErrorWithoutProxyIsUnchanged(t *testing.T) {
+	c, err := New("https://managed.example.com", "env1", "tok")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	got := c.requestError("request", errNotReachable{}).Error()
+
+	if strings.Contains(got, "proxy") {
+		t.Errorf("error mentions a proxy when none is set: %q", got)
+	}
+	if !strings.Contains(got, "request failed") {
+		t.Errorf("error lost its context: %q", got)
+	}
+}
+
+type errNotReachable struct{}
+
+func (errNotReachable) Error() string { return "dial tcp: connection refused" }

--- a/pkg/client/concurrency_test.go
+++ b/pkg/client/concurrency_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtmgd/pkg/config"
+)
+
+// configWithContexts builds a config of n contexts sharing one token, so
+// MultiRequest can construct a Client for each without reaching the network.
+func configWithContexts(n int) *config.Config {
+	cfg := &config.Config{
+		Tokens: []config.NamedToken{{Name: "tok", Token: "dt0c01.TEST"}},
+	}
+	for i := 0; i < n; i++ {
+		cfg.Contexts = append(cfg.Contexts, config.NamedContext{
+			Name: fmt.Sprintf("env%02d", i),
+			Context: config.Context{
+				Host:     "https://managed.example.com",
+				EnvID:    fmt.Sprintf("e%02d", i),
+				TokenRef: "tok",
+			},
+		})
+	}
+	return cfg
+}
+
+// peakTracker records the highest number of simultaneous calls observed.
+type peakTracker struct {
+	mu      sync.Mutex
+	current int
+	peak    int
+	total   atomic.Int64
+}
+
+func (p *peakTracker) enter() {
+	p.mu.Lock()
+	p.current++
+	if p.current > p.peak {
+		p.peak = p.current
+	}
+	p.mu.Unlock()
+	p.total.Add(1)
+}
+
+func (p *peakTracker) exit() {
+	p.mu.Lock()
+	p.current--
+	p.mu.Unlock()
+}
+
+// TestMultiRequestCapsConcurrency is the finding: 30 contexts used to produce
+// 30 simultaneous requests to the same cluster, which answers 429 and then
+// receives three equally large retry waves.
+func TestMultiRequestCapsConcurrency(t *testing.T) {
+	const contexts, limit = 30, 4
+
+	var p peakTracker
+	results, err := MultiRequest(configWithContexts(contexts), "ALL_ENVIRONMENTS", limit,
+		func(c *Client) (interface{}, error) {
+			p.enter()
+			// Long enough that unbounded goroutines would overlap; the cap is
+			// what keeps the observed peak at or below the limit.
+			time.Sleep(20 * time.Millisecond)
+			p.exit()
+			return "ok", nil
+		})
+	if err != nil {
+		t.Fatalf("MultiRequest() error = %v", err)
+	}
+
+	if got := int(p.total.Load()); got != contexts {
+		t.Errorf("apiCall ran %d times, want once per context (%d)", got, contexts)
+	}
+	if p.peak > limit {
+		t.Errorf("peak concurrency = %d, want at most %d", p.peak, limit)
+	}
+	if p.peak < 2 {
+		t.Errorf("peak concurrency = %d — the fan-out serialised instead of running in parallel", p.peak)
+	}
+	if len(results) != contexts {
+		t.Errorf("len(results) = %d, want %d", len(results), contexts)
+	}
+	for _, r := range results {
+		if r.Error != nil {
+			t.Errorf("context %s errored: %v", r.Name, r.Error)
+		}
+	}
+}
+
+// TestMultiRequestConcurrencyFallback: a caller that passes nothing sensible
+// still gets a bound rather than the old unbounded behaviour.
+func TestMultiRequestConcurrencyFallback(t *testing.T) {
+	const contexts = DefaultConcurrency + 12
+
+	var p peakTracker
+	_, err := MultiRequest(configWithContexts(contexts), "ALL_ENVIRONMENTS", 0,
+		func(c *Client) (interface{}, error) {
+			p.enter()
+			time.Sleep(20 * time.Millisecond)
+			p.exit()
+			return "ok", nil
+		})
+	if err != nil {
+		t.Fatalf("MultiRequest() error = %v", err)
+	}
+
+	if p.peak > DefaultConcurrency {
+		t.Errorf("peak concurrency = %d with limit 0, want at most DefaultConcurrency (%d)", p.peak, DefaultConcurrency)
+	}
+}
+
+// TestMultiRequestPreservesOrder guards the property the semaphore could
+// plausibly have broken: results are indexed by context position, not by
+// completion order.
+func TestMultiRequestPreservesOrder(t *testing.T) {
+	cfg := configWithContexts(8)
+
+	results, err := MultiRequest(cfg, "ALL_ENVIRONMENTS", 3,
+		func(c *Client) (interface{}, error) { return c.APIBaseURL(), nil })
+	if err != nil {
+		t.Fatalf("MultiRequest() error = %v", err)
+	}
+
+	for i, r := range results {
+		if r.Name != cfg.Contexts[i].Name {
+			t.Errorf("results[%d].Name = %q, want %q", i, r.Name, cfg.Contexts[i].Name)
+		}
+	}
+}

--- a/pkg/client/diagnostic.go
+++ b/pkg/client/diagnostic.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -10,17 +11,32 @@ func DiagnoseError(err error) string {
 	if err == nil {
 		return ""
 	}
+
+	// An *ErrAPI carries the status code as a number, so it is answered from
+	// the code alone and the text is never consulted. Part of that text comes
+	// from the server: a 400 whose message reads "see RFC 404 for details"
+	// was previously diagnosed as a missing resource. An unrecognised status
+	// yields no hint, which is correct — falling through to substring
+	// matching is exactly the bug.
+	var apiErr *ErrAPI
+	if errors.As(err, &apiErr) {
+		return diagnoseStatus(apiErr.StatusCode)
+	}
+
 	msg := err.Error()
 
 	switch {
+	// The status-substring cases remain for errors that are not *ErrAPI —
+	// notably ones rebuilt from text, which the tests and older call paths
+	// still produce.
 	case strings.Contains(msg, "401"):
-		return "Authentication failed. Check your API token and ensure it hasn't expired.\n  Run: dtmgd config set-credentials <token-ref> --token <new-token>"
+		return diagnoseStatus(401)
 	case strings.Contains(msg, "403"):
-		return "Permission denied. Your API token may be missing required scopes.\n  Required scopes: DataExport, ReadConfig, ReadLogContent, ReadEvents, ReadProblems, ReadSecurityProblems, ReadSLO"
+		return diagnoseStatus(403)
 	case strings.Contains(msg, "404"):
-		return "Resource not found. Check the ID and ensure you're using the correct environment."
+		return diagnoseStatus(404)
 	case strings.Contains(msg, "429"):
-		return "Rate limited by the Dynatrace API. Wait a moment and retry, or reduce request frequency."
+		return diagnoseStatus(429)
 	case strings.Contains(msg, "connection refused"):
 		return "Connection refused. Check that the host URL is correct and the cluster is reachable.\n  Run: dtmgd get environments"
 	case strings.Contains(msg, "no such host"):
@@ -33,6 +49,22 @@ func DiagnoseError(err error) string {
 		return "Token reference not found. Store it with:\n  dtmgd config set-credentials <token-ref> --token <api-token>"
 	case strings.Contains(msg, "no current context"):
 		return "No context configured. Set one up with:\n  dtmgd config set-context <name> --host <url> --env-id <id> --token-ref <ref>"
+	}
+	return ""
+}
+
+// diagnoseStatus maps an HTTP status code to its hint, so the structured and
+// text-matched paths above cannot drift apart.
+func diagnoseStatus(code int) string {
+	switch code {
+	case 401:
+		return "Authentication failed. Check your API token and ensure it hasn't expired.\n  Run: dtmgd config set-credentials <token-ref>"
+	case 403:
+		return "Permission denied. Your API token may be missing required scopes.\n  Required scopes: DataExport, ReadConfig, ReadLogContent, ReadEvents, ReadProblems, ReadSecurityProblems, ReadSLO"
+	case 404:
+		return "Resource not found. Check the ID and ensure you're using the correct environment."
+	case 429:
+		return "Rate limited by the Dynatrace API. Wait a moment and retry, or reduce request frequency."
 	}
 	return ""
 }

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,15 +1,61 @@
 package client
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // ErrAPI represents an HTTP error response from the Dynatrace Managed API.
 type ErrAPI struct {
 	StatusCode int
-	Body       string
+	// Body is the complete response body. It is kept for callers that need
+	// it — the -vv response dump prints the raw body from resty directly —
+	// but Error deliberately does not return all of it. See apiErrorMessage.
+	Body string
 }
 
+// maxAPIMessageLen caps the API-supplied text that reaches a user-facing
+// error. Dynatrace validation messages are a sentence; anything much longer
+// is a stack trace or a dump, which is what the cap is there to stop.
+const maxAPIMessageLen = 200
+
 func (e *ErrAPI) Error() string {
-	return fmt.Sprintf("API error %d: %s", e.StatusCode, e.Body)
+	if msg := apiErrorMessage(e.Body); msg != "" {
+		return fmt.Sprintf("API error %d: %s", e.StatusCode, msg)
+	}
+	return fmt.Sprintf("API error %d", e.StatusCode)
+}
+
+// apiErrorMessage extracts the human-readable message from a Dynatrace API
+// error envelope, and nothing else.
+//
+// Forwarding the whole body used to put every field the cluster returned into
+// stderr and into the agent-mode JSON envelope, where agent frameworks persist
+// it. Observed content included constraint-violation paths and parameter
+// locations, which describe the API's internal validation routing; on other
+// Managed versions the same unconditional path could carry exception chains,
+// internal service names or cluster hostnames.
+//
+// Only error.message is surfaced, because that is the part written for a
+// human to read. A body in any other shape yields "", so the caller reports
+// the status code alone rather than guessing what is safe to print.
+func apiErrorMessage(body string) string {
+	if body == "" {
+		return ""
+	}
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		return ""
+	}
+	msg := envelope.Error.Message
+	if len(msg) > maxAPIMessageLen {
+		msg = msg[:maxAPIMessageLen] + "…"
+	}
+	return msg
 }
 
 // APIError returns a new ErrAPI.

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+// realBody is the shape a Dynatrace Managed cluster actually returns for a
+// rejected request. constraintViolations describes the API's internal
+// validation routing — parameter names and whether each was matched in the
+// path or the query string — and used to be forwarded verbatim to stderr and
+// into the agent-mode JSON envelope.
+const realBody = `{"error":{"code":400,"message":"Constraints violated.","constraintViolations":[` +
+	`{"path":"problemId","message":"Invalid format.","parameterLocation":"PATH","location":null},` +
+	`{"path":"entityId","message":"Invalid format.","parameterLocation":"QUERY","location":null}]}}`
+
+func TestErrAPIDoesNotForwardWholeBody(t *testing.T) {
+	err := APIError(400, realBody)
+
+	got := err.Error()
+
+	// The actionable sentence survives.
+	if !strings.Contains(got, "Constraints violated.") {
+		t.Errorf("error dropped the message users need: %q", got)
+	}
+	// The internal fields do not.
+	for _, leak := range []string{"parameterLocation", "constraintViolations", "PATH", "QUERY", "problemId"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("error still leaks %q: %q", leak, got)
+		}
+	}
+}
+
+func TestErrAPIUnknownBodyShape(t *testing.T) {
+	// A body that is not the Dynatrace envelope could be anything — an HTML
+	// error page from a proxy, a Java stack trace, a plain string. Nothing is
+	// guessed at: the status code stands alone.
+	for _, body := range []string{
+		"Unauthorized",
+		"<html><body>502 Bad Gateway - internal-lb-07.corp</body></html>",
+		`{"unexpected":"shape"}`,
+		"",
+	} {
+		got := APIError(403, body).Error()
+		if got != "API error 403" {
+			t.Errorf("body %q produced %q, want the bare status", body, got)
+		}
+	}
+}
+
+func TestErrAPICapsMessageLength(t *testing.T) {
+	long := strings.Repeat("A", maxAPIMessageLen*3)
+	err := APIError(500, `{"error":{"message":"`+long+`"}}`)
+
+	got := err.Error()
+
+	if len(got) > maxAPIMessageLen+64 {
+		t.Errorf("message was not capped: %d chars", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncation was not signalled: %q", got)
+	}
+}
+
+// TestErrAPIStillDiagnosable is the regression this change could plausibly
+// have caused: DiagnoseError matches on status-code substrings, so stripping
+// the body must not take the hints with it.
+func TestErrAPIStillDiagnosable(t *testing.T) {
+	cases := map[int]string{
+		401: "Authentication failed",
+		403: "Permission denied",
+		404: "Resource not found",
+		429: "Rate limited",
+	}
+	for code, wantHint := range cases {
+		hint := DiagnoseError(APIError(code, "Unauthorized"))
+		if !strings.Contains(hint, wantHint) {
+			t.Errorf("status %d lost its diagnosis: got %q, want it to contain %q", code, hint, wantHint)
+		}
+	}
+}
+
+// TestErrAPINoCrossStatusFalseMatch is a side benefit worth pinning: with the
+// body forwarded, a 400 whose text merely mentioned "404" was diagnosed as a
+// missing resource. Dropping the body removes that confusion.
+func TestErrAPINoCrossStatusFalseMatch(t *testing.T) {
+	err := APIError(400, `{"error":{"message":"see RFC 404 for details"}}`)
+
+	if hint := DiagnoseError(err); strings.Contains(hint, "Resource not found") {
+		t.Errorf("a 400 was diagnosed from text in its own message: %q", hint)
+	}
+}

--- a/pkg/client/multi.go
+++ b/pkg/client/multi.go
@@ -15,26 +15,56 @@ type EnvResult struct {
 	Error error
 }
 
+// DefaultConcurrency caps how many environments are queried at once.
+//
+// The fan-out used to be unbounded: one goroutine per context, each with its
+// own resty client and connection pool, all launched at the same instant. A
+// realistic Managed deployment hosts 20-50 environment IDs on one cluster, so
+// `--env ALL_ENVIRONMENTS` sent that many simultaneous requests to a single
+// endpoint. The cluster answers 429, and because every goroutine is retrying
+// on the same 1-second schedule, each retry wave is as large as the original
+// burst — three times over before anything fails. wg.Wait then holds all
+// output until the slowest of them finishes.
+//
+// Ten is low enough to stay under typical rate limits and high enough that
+// small configurations see no serialisation at all.
+const DefaultConcurrency = 10
+
 // MultiRequest fans out an API call to one or more environments in parallel.
 // envSpec can be:
 //   - "" (empty) → current context only
 //   - "ALL_ENVIRONMENTS" → all configured contexts
 //   - "prod;staging" → semicolon-separated context names
 //
+// maxConcurrency caps simultaneous requests; values below 1 mean
+// DefaultConcurrency.
+//
 // The apiCall function receives a Client and should perform the request.
-func MultiRequest(cfg *config.Config, envSpec string, apiCall func(c *Client) (interface{}, error)) ([]EnvResult, error) {
+func MultiRequest(cfg *config.Config, envSpec string, maxConcurrency int, apiCall func(c *Client) (interface{}, error)) ([]EnvResult, error) {
 	contexts, err := resolveContexts(cfg, envSpec)
 	if err != nil {
 		return nil, err
+	}
+
+	if maxConcurrency < 1 {
+		maxConcurrency = DefaultConcurrency
 	}
 
 	results := make([]EnvResult, len(contexts))
 	var wg sync.WaitGroup
 	wg.Add(len(contexts))
 
+	// A buffered channel is the semaphore. Acquiring inside the goroutine
+	// rather than before launching it keeps this non-blocking for the caller:
+	// all goroutines start, and the channel decides how many are in flight.
+	sem := make(chan struct{}, maxConcurrency)
+
 	for i, nc := range contexts {
 		go func(idx int, nc config.NamedContext) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
 			r := EnvResult{Name: nc.Name}
 
 			// The bare error is deliberate: UnwrapSingle returns it as-is

--- a/pkg/client/pagination_test.go
+++ b/pkg/client/pagination_test.go
@@ -107,8 +107,14 @@ func TestAPIError(t *testing.T) {
 	if apiErr.StatusCode != 401 {
 		t.Errorf("expected 401, got %d", apiErr.StatusCode)
 	}
-	if apiErr.Error() != "API error 401: Unauthorized" {
+	// "Unauthorized" is not a Dynatrace error envelope, so no message is
+	// extracted and the status code stands alone. The body remains on the
+	// struct for the -vv dump and for programmatic callers.
+	if apiErr.Error() != "API error 401" {
 		t.Errorf("unexpected error message: %s", apiErr.Error())
+	}
+	if apiErr.Body != "Unauthorized" {
+		t.Errorf("Body = %q, want it preserved on the struct", apiErr.Body)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,7 +120,7 @@ func LoadFrom(path string) (*Config, error) {
 	// and Config.GetToken.
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
+		return nil, parseError(path, err)
 	}
 	// Apply defaults for fields that may be absent in minimal configs.
 	if cfg.APIVersion == "" {
@@ -129,6 +130,27 @@ func LoadFrom(path string) (*Config, error) {
 		cfg.Kind = "Config"
 	}
 	return &cfg, nil
+}
+
+// parseError converts a yaml decode failure into a message safe to show.
+//
+// yaml.v3 quotes the offending value in type errors, truncated to ten
+// characters. Because --config accepts any readable path, forwarding that text
+// turns a config flag into a short read primitive: `dtmgd --config /etc/hostname`
+// printed the machine's hostname, and in agent mode the same text lands in the
+// JSON error.message that agent frameworks record. Ten characters with no way
+// to page through more is too constrained to be a security finding, but the
+// error has no reason to echo file content at all.
+//
+// Syntax errors are forwarded unchanged: they report a line number and a
+// structural problem ("did not find expected key") without quoting values, and
+// they are the errors a user most often needs to act on.
+func parseError(path string, err error) error {
+	var typeErr *yaml.TypeError
+	if errors.As(err, &typeErr) {
+		return fmt.Errorf("failed to parse config file at %s: it is not valid dtmgd configuration", path)
+	}
+	return fmt.Errorf("failed to parse config file at %s: %w", path, err)
 }
 
 // Save saves the config to the default path.

--- a/pkg/config/parseerror_test.go
+++ b/pkg/config/parseerror_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadFromDoesNotEchoFileContent is PRISM-13823 note 2. Because --config
+// accepts any readable path, a yaml type error that quotes the offending value
+// turns the flag into a short read primitive: `dtmgd --config /etc/hostname`
+// printed the machine's hostname to stderr, and into agent-mode JSON.
+func TestLoadFromDoesNotEchoFileContent(t *testing.T) {
+	dir := t.TempDir()
+
+	// A single scalar where a mapping is expected — the shape /etc/hostname
+	// has, and the shape that produces a yaml.TypeError.
+	path := filepath.Join(dir, "hostname")
+	const secretish = "DT-JWKYTT3"
+	if err := os.WriteFile(path, []byte(secretish+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFrom(path)
+	if err == nil {
+		t.Fatal("LoadFrom() succeeded on a non-config file")
+	}
+
+	if strings.Contains(err.Error(), secretish) {
+		t.Errorf("error echoed the file's content: %v", err)
+	}
+	// The path still has to be named, or the user cannot tell which file the
+	// complaint is about.
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error does not name the offending file: %v", err)
+	}
+}
+
+// TestLoadFromKeepsSyntaxDiagnostics guards against over-correcting. A syntax
+// error reports a line number and a structural problem without quoting values,
+// and it is the error users most often need to act on — replacing it with a
+// generic message would trade a non-finding for a real usability loss.
+func TestLoadFromKeepsSyntaxDiagnostics(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broken.yaml")
+	if err := os.WriteFile(path, []byte("contexts:\n  - name: prod\n   bad indent here\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFrom(path)
+	if err == nil {
+		t.Fatal("LoadFrom() succeeded on malformed yaml")
+	}
+
+	if !strings.Contains(err.Error(), "line") {
+		t.Errorf("syntax error lost its line number: %v", err)
+	}
+}
+
+// TestLoadFromMissingFileUnchanged confirms the not-found path still gives its
+// actionable message rather than being swallowed by the new parse handling.
+func TestLoadFromMissingFileUnchanged(t *testing.T) {
+	_, err := LoadFrom(filepath.Join(t.TempDir(), "absent"))
+	if err == nil {
+		t.Fatal("LoadFrom() succeeded on a missing file")
+	}
+	if !strings.Contains(err.Error(), "set-context") {
+		t.Errorf("missing-file error lost its guidance: %v", err)
+	}
+}


### PR DESCRIPTION
Addresses five of the eleven informational notes in **PRISM-13823** — the pentest's explicitly non-tracked observations list ("we do not track the progress of these issues"). Each one is either an unbounded disclosure path or a case where one code path silently disagreed with the rest of the tool.

Independent of #33 (the three tracked vulnerabilities); no file overlap except `README.md`.

| Note | Finding | Category |
|---|---|---|
| 7 | Full API response body forwarded in `ErrAPI.Error()` | Information exposure |
| 10 | `GetCluster()` built its own resty client — proxy, retry, hooks bypassed | Design |
| 11 | Proxy state invisible at every verbosity level | Design |
| 8 | Unbounded goroutine fan-out in `MultiRequest()` | Design |
| 2 | YAML parse errors echoed file content | Information exposure |

---

## Note 7 — the whole response body reached the user

`APIError` is constructed with `resp.String()` — the complete body — and `Error()` formatted all of it into the message. That lands on stderr in human mode and in the `error.message` field of the agent-mode JSON envelope, where agent frameworks record it.

What the pentest actually observed was low-value (constraint-violation paths, `parameterLocation`), but the mechanism is unconditional: on another Managed version the same path carries whatever the cluster returns — exception chains, internal service names, cluster hostnames.

Now only `error.message` from the recognised Dynatrace envelope is surfaced, capped at 200 chars. **Any other body shape yields the bare status code** rather than a guess about what is safe to print. `ErrAPI.Body` keeps the full body, and `-vv` still dumps the raw response.

```
before:  API error 400: {"error":{"code":400,"message":"Constraints violated.",
                "constraintViolations":[{"path":"problemId","parameterLocation":"PATH",...}]}}
after:   API error 400: Constraints violated.
```

**This forced a second fix.** `DiagnoseError` matched status codes as *substrings anywhere in the message*, so it was reading digits out of server-supplied text — a 400 whose message mentioned "404" was diagnosed as a missing resource. It now reads `StatusCode` off `*ErrAPI` and never consults the text for those errors. Substring matching stays for non-`*ErrAPI` errors.

I found this because a test I wrote asserting it as a "side benefit" **failed** — the extracted message can still contain digits. The test is in the diff, now passing against a real fix rather than an assumed one.

## Note 10 — `GetCluster` bypassed everything

It called `resty.New()` per request, inheriting none of what `New` configures: no proxy, no retry, no `-vv` hooks, no `User-Agent`.

The proxy is the consequence that matters. Where egress must traverse an inspection proxy, `dtmgd get environments` connected **directly** while every other command went through it — so proxy audit logs had an incomplete picture of dtmgd activity, and DLP/URL-filtering controls saw nothing.

Both clients are now built by one `newRestyClient` and held on `Client`; `SetProxy` and `SetVerbosity` apply to both. The test points the client at an unreachable proxy and asserts `GetCluster` **fails** — if it still succeeded, the proxy would still be bypassed.

## Note 11 — proxy state was invisible

No verbosity level printed the proxy, making these indistinguishable: no proxy, proxy working, proxy silently bypassed (note 10). The proxy in effect is now named on the `-v` request line and in transport errors:

```
==> GET https://managed.company.com/e/abc/api/v2/problems (via proxy http://proxy.corp:8080)
✗ request failed (via proxy http://bad-proxy.internal:8080): dial tcp: lookup bad-proxy.internal: no such host
```

Errors are wrapped, not replaced, so `DiagnoseError` still matches `no such host` / `connection refused`.

## Note 8 — unbounded fan-out

One goroutine per context, no cap, each with its own connection pool. A Managed cluster commonly hosts 20–50 environment IDs, so `--env ALL_ENVIRONMENTS` fired that many simultaneous requests at one endpoint. The cluster answers 429; every goroutine retries on the same 1-second schedule, so **each retry wave is as large as the original burst**, three times over — and `wg.Wait` withholds all output until the slowest finishes.

Capped with a buffered-channel semaphore, default 10, exposed as `--concurrency`. The test drives 30 contexts at a limit of 4 and asserts the observed peak — and also asserts the peak is ≥ 2, so a change that accidentally serialised the fan-out would fail too.

Results stay indexed by context position; a separate test pins that, since the semaphore is exactly the kind of change that could have broken it.

## Note 2 — parse errors echoed file content

yaml.v3 quotes the offending value in *type* errors, truncated to ten characters. Since `--config` takes any readable path, forwarding that made the flag a short read primitive — `dtmgd --config /etc/hostname` printed the hostname.

Type errors now give a generic message naming only the path. **Syntax errors are still forwarded**: they carry a line number and a structural complaint without quoting values, and they are the errors users actually need to act on. Replacing those too would trade a non-finding for a real usability loss.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- `go test ./pkg/config/... ./pkg/client/... ./cmd/... ./pkg/output/...` — all `ok`
- Total coverage **70.4%**, above the 60% gate

One existing test (`TestAPIError`) asserted the old body-forwarding contract and is updated deliberately — it now also pins that `Body` survives on the struct.

I could not run `-race` locally (no gcc in this sandbox). CI runs `go test -race ./...`, so the semaphore is race-checked there. Flagging it rather than implying I verified it.

`TestSetProxyReachesClusterClient` takes ~6s: the cluster client now shares the retry policy, so an unreachable proxy is retried with backoff. That delay is the fix working; there's a comment saying so.

## Deliberately not addressed

**Note 4** (unsolicited `securityProblems` list call). The suggested fix — direct `GET /securityProblems/{id}` first, fall back to the list on 404 — cannot work. The list call is already guarded by `displayIDRegexp`, so it only fires for `S-NNN` display IDs, which are not valid UUID path segments; the direct GET would 404 every time and the fallback would always run. A real fix needs a server-side selector I can't verify without a live cluster. Better left open than "fixed" wrongly.

**Note 5** (agent mode auto-activated by env var) changes default behaviour for every existing user — a product call, not mine. Worth noting it reproduced during this work: `dtmgd config view` in this session returned JSON because `CLAUDECODE` is set.

**Notes 6, 9** (destructive `skills install --force`, unpinned GitHub Actions) are coming in a separate PR.

**Notes 1, 3** are covered by #33.

## Follow-up after both PRs land

The 401 diagnostic hint now reads `dtmgd config set-credentials <token-ref>`, which prompts for a token only once #33 merges. Harmless in the meantime — it just omits a flag — but worth a glance when sequencing the merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
