### PR TITLE
fix: pin CI actions to commit SHAs and stop skills --force deleting user files (PRISM-13823 notes 6, 9)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,11 @@ jobs:
             goarch: arm64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
@@ -59,7 +59,7 @@ jobs:
             -o dtmgd-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dtmgd-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dtmgd-*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           version: '~> v2'
           args: release --clean

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -10,13 +10,13 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,9 +12,9 @@ jobs:
   vulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,14 +15,14 @@ jobs:
     # Requires SNYK_API_TOKEN as a repository secret:
     # Settings → Secrets and variables → Actions → New repository secret
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@12140f4059e244892ae643824a95459a102120dd # master @ 2026-08-03
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,11 +18,11 @@ jobs:
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # required for SonarCloud blame/history analysis
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@v8.2.1
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     env:
       GOTOOLCHAIN: local
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -93,7 +93,7 @@ func init() {
 	skillsInstallCmd.Flags().String("for", "", "install for a specific agent (claude, copilot, cursor, junie, kiro, opencode)")
 	skillsInstallCmd.Flags().Bool("cross-client", false, "install to the shared .agents/skills/ directory (agentskills.io convention)")
 	skillsInstallCmd.Flags().Bool("global", false, "install to user-wide location instead of project directory")
-	skillsInstallCmd.Flags().Bool("force", false, "overwrite existing files without prompting")
+	skillsInstallCmd.Flags().Bool("force", false, "overwrite the skill's own files; anything else in the directory is left alone")
 	skillsInstallCmd.Flags().Bool("list", false, "list all supported agents and exit")
 
 	skillsUninstallCmd.Flags().String("for", "", "uninstall for a specific agent")
@@ -154,10 +154,11 @@ func runSkillsInstall(cmd *cobra.Command, _ []string) error {
 
 	if agentMode() {
 		return output.NewAgentPrinter("skills").Print(map[string]interface{}{
-			"action": map[bool]string{true: "updated", false: "installed"}[result.Replaced],
-			"agent":  result.Agent.Name,
-			"path":   result.Path,
-			"scope":  scope,
+			"action":    map[bool]string{true: "updated", false: "installed"}[result.Replaced],
+			"agent":     result.Agent.Name,
+			"path":      result.Path,
+			"scope":     scope,
+			"preserved": result.Preserved,
 		})
 	}
 
@@ -166,6 +167,13 @@ func runSkillsInstall(cmd *cobra.Command, _ []string) error {
 		verb = "Updated"
 	}
 	fmt.Printf("✓ %s %s skill: %s (%s)\n", verb, result.Agent.DisplayName, result.Path, scope)
+	// Say what was left alone. --force used to delete the whole directory, so
+	// anyone who kept notes or extra reference files beside SKILL.md lost them
+	// and only found out later.
+	if len(result.Preserved) > 0 {
+		output.PrintInfo("Left %d file(s) in place that are not part of the skill: %s",
+			len(result.Preserved), strings.Join(result.Preserved, ", "))
+	}
 	return nil
 }
 

--- a/pkg/skills/force_test.go
+++ b/pkg/skills/force_test.go
@@ -1,0 +1,98 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	dtmgdskill "github.com/dynatrace-oss/dtmgd/skills/dtmgd"
+)
+
+// TestInstallForcePreservesUserFiles is PRISM-13823 note 6.
+//
+// Install used to call os.RemoveAll(skillDir) whenever --force was passed and
+// a SKILL.md already existed. The whole directory went, not just the file the
+// command manages, and the only output — printed after the deletion — said
+// "Updated". Anything the user kept next to SKILL.md was unrecoverable.
+func TestInstallForcePreservesUserFiles(t *testing.T) {
+	base := t.TempDir()
+	agent, ok := FindAgent("claude")
+	if !ok {
+		t.Fatal("claude agent not found in the registry")
+	}
+
+	// First install creates the directory and SKILL.md.
+	first, err := Install(agent, base, false, false)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(first.Preserved) != 0 {
+		t.Errorf("fresh install reported preserved files: %v", first.Preserved)
+	}
+
+	// The user adds their own material beside it, and edits SKILL.md.
+	notes := filepath.Join(first.Path, "my-notes.md")
+	const notesBody = "cluster quirks I do not want to lose"
+	if err := os.WriteFile(notes, []byte(notesBody), 0600); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(first.Path, "reference")
+	if err := os.MkdirAll(nested, 0750); err != nil {
+		t.Fatal(err)
+	}
+	extra := filepath.Join(nested, "queries.md")
+	if err := os.WriteFile(extra, []byte("saved selectors"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	skillFile := filepath.Join(first.Path, skillFileName)
+	if err := os.WriteFile(skillFile, []byte("locally edited"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-install with --force.
+	second, err := Install(agent, base, false, true)
+	if err != nil {
+		t.Fatalf("Install(force) error = %v", err)
+	}
+	if !second.Replaced {
+		t.Error("Replaced = false, want true on a forced re-install")
+	}
+
+	// The user's files survive.
+	got, err := os.ReadFile(notes)
+	if err != nil {
+		t.Fatalf("--force deleted the user's file: %v", err)
+	}
+	if string(got) != notesBody {
+		t.Errorf("user file content changed: %q", got)
+	}
+	if _, err := os.ReadFile(extra); err != nil {
+		t.Errorf("--force deleted a nested user file: %v", err)
+	}
+
+	// SKILL.md is genuinely refreshed — that is what --force is for.
+	refreshed, err := os.ReadFile(skillFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(refreshed) == "locally edited" {
+		t.Error("--force did not overwrite SKILL.md")
+	}
+
+	// And the user is told what was kept.
+	if len(second.Preserved) != 2 {
+		t.Errorf("Preserved = %v, want the two user files", second.Preserved)
+	}
+}
+
+// TestUnmanagedFilesOnMissingDir covers the first-install case: nothing to
+// inspect is not an error.
+func TestUnmanagedFilesOnMissingDir(t *testing.T) {
+	got, err := unmanagedFiles(filepath.Join(t.TempDir(), "absent"), dtmgdskill.Content)
+	if err != nil {
+		t.Fatalf("unmanagedFiles() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("unmanagedFiles() = %v, want empty", got)
+	}
+}

--- a/pkg/skills/installer.go
+++ b/pkg/skills/installer.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	dtmgdskill "github.com/dynatrace-oss/dtmgd/skills/dtmgd"
@@ -92,6 +93,10 @@ type InstallResult struct {
 	Path     string
 	Global   bool
 	Replaced bool
+	// Preserved lists files that were already in the skill directory and are
+	// not part of the embedded skill, so they were left untouched. Install
+	// used to delete the whole directory on --force, taking these with it.
+	Preserved []string
 }
 
 // StatusResult describes the current installation state for an agent.
@@ -164,10 +169,21 @@ func Install(agent Agent, baseDir string, global bool, overwrite bool) (*Install
 		replaced = true
 	}
 
-	if replaced {
-		if err := os.RemoveAll(skillDir); err != nil {
-			return nil, fmt.Errorf("failed to remove existing skill directory %s: %w", skillDir, err)
-		}
+	// Deliberately no os.RemoveAll(skillDir) here.
+	//
+	// --force is documented as "overwrite existing files without prompting",
+	// but it used to delete the entire skill directory before writing — and
+	// the only output, printed after the fact, said "Updated". Anything the
+	// user had added or edited in there was gone with no warning, no
+	// confirmation, no dry-run and no way back short of their own version
+	// control.
+	//
+	// copyEmbeddedFS truncates the files it writes, so overwriting is all
+	// that --force ever needed. Files that are not part of the embedded skill
+	// are now left alone and reported.
+	preserved, err := unmanagedFiles(skillDir, dtmgdskill.Content)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := copyEmbeddedFS(dtmgdskill.Content, skillDir); err != nil {
@@ -175,11 +191,59 @@ func Install(agent Agent, baseDir string, global bool, overwrite bool) (*Install
 	}
 
 	return &InstallResult{
-		Agent:    agent,
-		Path:     skillDir,
-		Global:   global,
-		Replaced: replaced,
+		Agent:     agent,
+		Path:      skillDir,
+		Global:    global,
+		Replaced:  replaced,
+		Preserved: preserved,
 	}, nil
+}
+
+// unmanagedFiles lists files already under dir that the embedded skill will
+// not overwrite — that is, whatever the user put there themselves.
+//
+// A missing directory is not an error: it is the ordinary first-install case
+// and simply has nothing to preserve.
+func unmanagedFiles(dir string, embeddedFS fs.FS) ([]string, error) {
+	managed := make(map[string]bool)
+	err := fs.WalkDir(embeddedFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Ext(path) != ".go" {
+			managed[filepath.Clean(path)] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded skill: %w", err)
+	}
+
+	var extra []string
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if !managed[filepath.Clean(rel)] {
+			extra = append(extra, rel)
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("inspecting %s: %w", dir, err)
+	}
+	sort.Strings(extra)
+	return extra, nil
 }
 
 // copyEmbeddedFS copies all files from the embedded filesystem to destDir,


### PR DESCRIPTION
Addresses **PRISM-13823 notes 9 and 6** — supply chain, and a destructive default. Independent of #33 and #34; no file overlap with either.

---

## Note 9 — floating and mutable action references

`snyk.yml` pinned `snyk/actions/golang@master` — a **branch pointer**. Every run fetched whatever sat at the tip. A compromise of that repository (maintainer account takeover, a bad merge) would execute arbitrary code in a job holding `SNYK_API_TOKEN` and the default `GITHUB_TOKEN`, with no change on our side and no signal that anything had happened.

Every other workflow used version tags, which the upstream owner can force-push at any time. `release.yml` is the one that matters most: `goreleaser-action` runs with `permissions: contents: write`, so a rewritten tag there could tamper with published release binaries or forge GitHub Releases.

All **22 action references across 8 workflows** are now pinned to full commit SHAs, each carrying a comment naming the version it resolves to:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `v7` | `3d3c42e5…` |
| `actions/setup-go` | `v7` | `b7ad1dad…` |
| `actions/upload-artifact` | `v7` | `043fb46d…` |
| `golangci/golangci-lint-action` | `v9` | `ba0d7d2e…` |
| `SonarSource/sonarqube-scan-action` | `v8.2.1` | `22918119…` |
| `goreleaser/goreleaser-action` | `v7` | `f06c13b6…` |
| `snyk/actions/golang` | **`master`** | `12140f40…` |

```yaml
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

One detail worth flagging: `golangci-lint-action`'s `v9` is an **annotated tag**, so `git/ref/tags/v9` returns the tag object's hash, not a commit. I dereferenced it to the commit it points at. Pinning the tag object's own hash would have looked right and not worked.

**No dependabot change needed.** `.github/dependabot.yml` already tracks `github-actions` weekly, and dependabot understands SHA pins with a version comment — it rewrites both together. Worth confirming the digests stay fresh after this lands.

### Verification

```
$ grep -rn 'uses:' .github/workflows/ | grep -vE '@[0-9a-f]{40}'
(no output — every action is pinned to a commit SHA)
```

## Note 6 — `skills install --force` deleted the whole directory

`Install` called `os.RemoveAll(skillDir)` whenever `--force` was passed and a `SKILL.md` already existed. That removed the **entire directory**, not just the file the command manages. The only output — printed *after* the deletion — read:

```
✓ Updated Claude Code skill: /your/project/.claude/skills/dtmgd (project)
```

"Updated" concealed it. A user who kept notes or extra reference files beside `SKILL.md` lost them with no warning, no confirmation, no dry-run, and no way back short of their own version control. The flag's help text said only *"overwrite existing files without prompting"*.

`copyEmbeddedFS` truncates the files it writes, so **overwriting was all `--force` ever needed** — the delete bought nothing. It's gone. Files that aren't part of the embedded skill are left alone and reported:

```
✓ Updated Claude Code skill: /project/.claude/skills/dtmgd (project)
Left 2 file(s) in place that are not part of the skill: my-notes.md, reference/queries.md
```

Help text now describes what the flag actually does.

### Verification

The test installs, adds a user file and a nested user file, edits `SKILL.md`, then re-installs with `--force` — asserting the user's files survive *and* that `SKILL.md` was genuinely refreshed (otherwise "preserve everything" would be a trivial pass).

I mutation-checked it rather than trusting it:

```
# with os.RemoveAll restored:
--- FAIL: TestInstallForcePreservesUserFiles
    force_test.go:64: --force deleted the user's file: .../my-notes.md: no such file or directory
# with the fix:
ok  github.com/dynatrace-oss/dtmgd/pkg/skills
```

## Overall verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- `go test ./pkg/config/... ./pkg/client/... ./cmd/... ./pkg/output/...` — all `ok`

`pkg/skills` reports two failures **locally only** — `TestInstallAndStatusAndUninstall` and `TestStatusAll`. They are pre-existing and environmental: `Status()` consults `os.UserHomeDir()`, so a machine with dtmgd skills already installed fails the "fresh dir" assertion. I confirmed identical failures on clean `main` with my changes stashed. CI runners have no skills installed, which is why those are green there. My new tests in that package pass.

## Note on CI

The GitHub Actions outage from earlier today (`Failed to resolve action download info: Service Unavailable`) was still affecting runs when I pushed. If checks here look broken in ways unrelated to the diff, that is likely why — worth a re-run before reading anything into them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
