### PR TITLE
docs: record why Snyk, Dependabot and govulncheck disagreed on the x/crypto CVEs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -117,3 +117,17 @@ For `dtmgd` CLI usage patterns and command reference, see `skills/dtmgd/SKILL.md
 - **When it applies**: Triaging red checks on a dtmgd PR before assuming the code is at fault
 - **Date**: 2026-08-06
 - **Ref**: impl: resolve config env vars at point of use (#29)
+
+### Snyk, Dependabot and govulncheck resolve different dependency sets
+- **Context**: Six Snyk-sourced Jira tickets (PRISM-14120..14125) reported `golang.org/x/crypto` v0.51.0 CVEs against dtmgd. Dependabot never alerted and govulncheck never mentioned the module, which looks like two scanners missing something. They did not.
+- **Insight**: All three answer different questions and all three were right. `x/crypto` was a *phantom* module-graph entry contributed by `golang.org/x/net`'s go.mod: present in `go list -m all`, but with **no `go.sum` entry**, so no package of it was ever downloaded or linked. Snyk resolves the MVS module graph, so it reported it. GitHub's dependency graph is built from go.mod + go.sum, so it excluded it — and Dependabot cannot alert on a package it does not think you have. (Not an advisory-coverage gap: all six CVEs were in GitHub's Advisory Database from 2026-06-25, correctly attributed. The advisories were there; the package was not.) govulncheck is build-and-call-graph based, so it was silent too.
+- **When it applies**: Triaging any Snyk Go finding before spending time on it. `grep '<module>' go.sum || echo "graph-only, not in the build"` settles reachability in one command; confirm with `go list -deps ./...`. Beware one trap there: `vendor/golang.org/x/crypto/...` entries are the Go toolchain's own internal copy inside `crypto/tls`, not your dependency.
+- **Date**: 2026-08-06
+- **Ref**: fix(deps): raise golang.org/x/crypto floor past the ssh CVEs (#32)
+
+### Dependabot does not bump indirect Go deps on schedule — only via alerts, to the minimum version
+- **Context**: Asked why Snyk filed vulnerability tickets when Dependabot runs weekly. Dependabot was working — 16 PRs — yet `x/net` sat at v0.55.0 for a month with v0.56.0 and v0.57.0 published, and `x/sys` at v0.45.0 with v0.47.0 published.
+- **Insight**: Both stale modules are `// indirect`. Scheduled `gomod` version updates cover direct dependencies; every direct dep and GitHub Action got a prompt PR over the same period. An indirect dep moves only when a Dependabot **security alert** fires, and then only to the **minimum safe version** — PR #20 bumped `x/net` to exactly v0.55.0, the `first_patched_version` of GHSA-5cv4-jp36-h3mw, while v0.57.0 already existed. So the indirect floor drifts upward-never, and Snyk keeps reporting transitive CVEs for which no PR will ever arrive.
+- **When it applies**: Any "why didn't Dependabot catch this?" question, and any Go transitive-CVE remediation here. Fix the cause by bumping the *real* dependency whose go.mod contributes the requirement — a direct `require` on a module no package imports is dropped again by the next `go mod tidy`. A scheduled `go get -u ./... && go mod tidy` PR is the only thing that keeps indirect deps current.
+- **Date**: 2026-08-06
+- **Ref**: fix(deps): raise golang.org/x/crypto floor past the ssh CVEs (#32)


### PR DESCRIPTION
Two knowledge-base entries in `.claude/CLAUDE.md`, from triaging PRISM-14120..14125. Docs only — no code, no CI config.

Both answer a question that took real digging and will be asked again: **why did Snyk file six vulnerability tickets when Dependabot runs weekly and never said a word?**

## Entry 1 — the three scanners resolve different dependency sets

Snyk reported `golang.org/x/crypto` v0.51.0. Dependabot never alerted. govulncheck never mentioned the module. That looks like two scanners missing something. They weren't.

`x/crypto` was a **phantom module-graph entry** contributed by `x/net`'s go.mod — present in `go list -m all`, with **no `go.sum` entry**, so no package of it was ever downloaded or linked:

| Tool | Resolves | Verdict |
|---|---|---|
| Snyk | MVS module graph | reports it |
| Dependabot | go.mod + go.sum → GitHub dependency graph | can't see it |
| govulncheck | build + call graph | silent |

All three were right about their own question.

Worth stating plainly because it was my first assumption and it was wrong: **this was not an advisory-coverage gap.** All six CVEs had been in GitHub's Advisory Database since **2026-06-25**, six weeks before the tickets, correctly attributed to `golang.org/x/crypto`. The advisories were there; the package wasn't.

The entry carries the one-command triage — `grep '<module>' go.sum` — plus the trap that goes with it: `go list -deps` returns `vendor/golang.org/x/crypto/...` hits that are the **Go toolchain's own internal copy** inside `crypto/tls`, not your dependency. I nearly misread those as proof of reachability.

## Entry 2 — Dependabot won't bump indirect Go deps on schedule

Dependabot was working fine — 16 PRs. But:

| | pinned | newer available since |
|---|---|---|
| `x/net` | v0.55.0 | v0.56.0 (Jun 9), v0.57.0 (Jul 8) |
| `x/sys` | v0.45.0 | v0.46.0 (May 27), v0.47.0 (Jun 30) |

Weeks stale — while every *direct* dep and every Action got a prompt PR. Both stale modules are `// indirect`.

And the one `x/net` bump that did happen was a **security** update, not a scheduled one. The proof is exact: `GHSA-5cv4-jp36-h3mw`'s `first_patched_version` is **0.55.0**, and PR #20 stopped there on 2026-07-16 with 0.57.0 already published. Security updates take the *minimum safe version*, never latest.

So the indirect floor only ever moves when an alert forces it — and no alert could fire, because the package wasn't in the graph. **No Dependabot PR was ever going to arrive for this.**

The entry also records why the remediation had to bump `x/net` rather than `x/crypto`: a direct `require` on a module no package imports is dropped again by the next `go mod tidy`.

## Why this is worth tracking

`.claude/CLAUDE.md` became tracked in #31 precisely so findings like this are shared rather than sitting in one person's session. This one has a standing consequence: **Snyk will keep filing tickets for modules that aren't in the build**, and neither Dependabot nor govulncheck will corroborate them. Knowing the triage rule turns that from an investigation into one `grep`.

If you'd rather remove the cause than re-triage it each time, the lever is a scheduled `go get -u ./... && go mod tidy` PR — that's the only thing that keeps indirect deps current here. Not proposing it in this PR; flagging it as the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
